### PR TITLE
Change base image from stretch-run to buster-run

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:stretch-run
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:buster-run
 
 # Install XORG
 RUN install_packages xserver-xorg=1:7.7+19 \


### PR DESCRIPTION
I noticed that `Dockerfile.template` wouldn't build because the package repositories were returning 404. I believe this is because Debian Stretch is no longer LTS and has been archived. For anyone else that may find this project useful, I think it's a good idea to move to buster same as the Pi. I've tested the buster base image and was able to see the XFCE desktop. 